### PR TITLE
🏮 fix(exceptions): add string override

### DIFF
--- a/speckle/logging/exceptions.py
+++ b/speckle/logging/exceptions.py
@@ -6,7 +6,7 @@ class SpeckleException(Exception):
         self.message = message
         self.exception = exception
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return f"SpeckleException: {self.message}"
 
 
@@ -16,7 +16,7 @@ class SerializationException(SpeckleException):
         self.object = object
         self.unhandled_type = type(object)
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         return f"SpeckleException: Could not serialize object of type {self.unhandled_type}"
 
 
@@ -25,3 +25,6 @@ class GraphQLException(SpeckleException):
         super().__init__(message=message)
         self.errors = errors
         self.data = data
+
+    def __str__(self) -> str:
+        return f"GraphQLException: {self.message}"


### PR DESCRIPTION
Exceptions returned from `make_request()` were not being shown to the user as the `__repr__` override was not affecting the printed string representation. This meant the response to a failed request was just...nothing. Oops! Fixed this here by changing the `__repr__` overrides to `__str__` overrides

do classes no longer default to the `__repr__` override?
to investigate...