### PR TITLE
🍰 Chunking of long lists

### DIFF
--- a/speckle/api/operations.py
+++ b/speckle/api/operations.py
@@ -66,7 +66,7 @@ def receive(
     # try local transport first. if the parent is there, we assume all the children are there and continue wth deserialisation using the local transport
     obj_string = local_transport.get_object(obj_id)
     if obj_string:
-        base = serializer.read_json(id=obj_id, obj_string=obj_string)
+        base = serializer.read_json(obj_string=obj_string)
         return base
 
     if not remote_transport:
@@ -78,4 +78,16 @@ def receive(
         id=obj_id, target_transport=local_transport
     )
 
-    return serializer.read_json(id=obj_id, obj_string=obj_string)
+    return serializer.read_json(obj_string=obj_string)
+
+
+def serialize(base: Base) -> str:
+    serializer = BaseObjectSerializer()
+
+    return serializer.write_json(base)[1]
+
+
+def deserialize(obj_string: str) -> Base:
+    serializer = BaseObjectSerializer()
+
+    return serializer.read_json(obj_string=obj_string)

--- a/speckle/objects/__init__.py
+++ b/speckle/objects/__init__.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+import inspect
+import pkgutil
+from importlib import import_module
+from .base import Base
+
+
+for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):
+    imported_module = import_module("." + name, package=__name__)
+    classes = inspect.getmembers(imported_module, inspect.isclass)
+    for c in classes:
+        if issubclass(c[1], Base):
+            setattr(sys.modules[__name__], c[0], c[1])

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
-from speckle.logging.exceptions import SpeckleException
-
-from typing import Dict, List, Optional, Any
 
 from pydantic import BaseModel
 from pydantic.main import Extra
+from typing import Dict, List, Optional, Any
+from speckle.transports.memory import MemoryTransport
+from speckle.logging.exceptions import SpeckleException
+
 
 PRIMITIVES = (int, float, str, bool)
 
@@ -78,6 +79,19 @@ class Base(BaseModel):
         """Get the total count of children Base objects"""
         parsed = []
         return 1 + self._count_descendants(self, parsed)
+
+    def get_id(self, decompose: bool = False) -> str:
+        if self.id and not decompose:
+            return self.id
+        else:
+            from speckle.serialization.base_object_serializer import (
+                BaseObjectSerializer,
+            )
+
+            serializer = BaseObjectSerializer()
+            if decompose:
+                serializer.write_transports = [MemoryTransport()]
+            return serializer.traverse_base(self)[0]
 
     def _count_descendants(self, base: Base, parsed: List) -> int:
         if base in parsed:

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -14,6 +14,7 @@ class Base(BaseModel):
     totalChildrenCount: Optional[int] = None
     applicationId: Optional[str] = None
     speckle_type: Optional[str] = "Base"
+    chunks: Dict[str, int] = {}
 
     def __init__(self, **kwargs) -> None:
         super().__init__()

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -14,7 +14,7 @@ class Base(BaseModel):
     totalChildrenCount: Optional[int] = None
     applicationId: Optional[str] = None
     speckle_type: Optional[str] = "Base"
-    chunks: Dict[str, int] = {}
+    _chunkable: Dict[str, int] = {}  # dict of chunkable props and their max chunk size
 
     def __init__(self, **kwargs) -> None:
         super().__init__()

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -22,7 +22,7 @@ class Base(BaseModel):
         self.__dict__.update(kwargs)
 
     def __repr__(self) -> str:
-        return f"{self.speckle_type}(id: {self.id}, speckle_type: {self.speckle_type}, totalChildrenCount: {self.totalChildrenCount})"
+        return f"{self.__class__.__name__}(id: {self.id}, speckle_type: {self.speckle_type}, totalChildrenCount: {self.totalChildrenCount})"
 
     def __str__(self) -> str:
         return self.__repr__()

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -120,3 +120,7 @@ class Base(BaseModel):
 
     class Config:
         extra = Extra.allow
+
+
+class DataChunk(Base):
+    data: List[Any] = []

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -17,10 +17,14 @@ class Base(BaseModel):
 
     def __init__(self, **kwargs) -> None:
         super().__init__()
+        self.speckle_type = self.__class__.__name__
         self.__dict__.update(kwargs)
 
+    def __repr__(self) -> str:
+        return f"{self.speckle_type}(id: {self.id}, speckle_type: {self.speckle_type}, totalChildrenCount: {self.totalChildrenCount})"
+
     def __str__(self) -> str:
-        return f"Base(id: {self.id}, speckle_type: {self.speckle_type}, totalChildrenCount: {self.totalChildrenCount})"
+        return self.__repr__()
 
     def __setitem__(self, name: str, value: Any) -> None:
         self.__dict__[name] = value

--- a/speckle/objects/mesh.py
+++ b/speckle/objects/mesh.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+from .base import Base
+
+CHUNKABLE_PROPS = {
+    "vertices": 2000,
+    "faces": 2000,
+    "colors": 2000,
+    "textureCoordinates": 2000,
+}
+
+
+class Mesh(Base):
+    vertices: List[float] = None
+    faces: List[int] = None
+    colors: List[int] = None
+    textureCoordinates: List[float] = None
+    id: Optional[str] = None
+    totalChildrenCount: Optional[int] = None
+    applicationId: Optional[str] = None
+    speckle_type: Optional[str] = None
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._chunkable.update(CHUNKABLE_PROPS)

--- a/speckle/objects/mesh.py
+++ b/speckle/objects/mesh.py
@@ -18,10 +18,6 @@ class Mesh(Base):
     faces: List[int] = None
     colors: List[int] = None
     textureCoordinates: List[float] = None
-    id: Optional[str] = None
-    totalChildrenCount: Optional[int] = None
-    applicationId: Optional[str] = None
-    speckle_type: Optional[str] = None
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/speckle/serialization/base_object_serializer.py
+++ b/speckle/serialization/base_object_serializer.py
@@ -225,10 +225,6 @@ class BaseObjectSerializer:
         if obj["speckle_type"] == "reference":
             obj = self.get_child(obj=obj)
 
-        # if it's a chunk, we know the shape of it already so we can just create the chunk and return it
-        if obj["speckle_type"] == "DataChunk":
-            return DataChunk(id=obj["id"], data=obj["data"])
-
         # initialise the base object using `speckle_type`
         base = getattr(objects, obj["speckle_type"], Base)()
 

--- a/speckle/transports/memory.py
+++ b/speckle/transports/memory.py
@@ -29,7 +29,7 @@ class MemoryTransport(AbstractTransport):
 
     def get_object(self, id: str) -> str or None:
         if id in self.objects:
-            return json.dumps(self.objects[id])
+            return self.objects[id]
         else:
             return None
 


### PR DESCRIPTION
Recently, a new feature was introduced in `speckle-sharp` - chunking! This allows you to "chunk" long unmanageable lists into smaller `DataChunks` that can be detached and sent separately to avoid a clunky and memory intensive serialisation process (think serialising a list of points or surfaces thousands and thousands of items long!). This is the python implementation of the same functionality.

To use this in an object, you simply populate the new `_chunkable` dict with the name of your chunkable prop as the key and the max chunk size as the value.

```py
CHUNKABLE_PROPS = {
    "vertices": 2000,
    "faces": 2000,
    "colors": 2000,
    "textureCoordinates": 2000,
}

class Mesh(Base):
    vertices: List[float] = None
    faces: List[int] = None
    colors: List[int] = None
    textureCoordinates: List[float] = None

    def __init__(self, **kwargs) -> None:
        super().__init__(**kwargs)
        self._chunkable.update(CHUNKABLE_PROPS)
```

This will chunk up the lists upon serialisation and put the chunks back together upon deserialisation. [Here](https://staging.speckle.dev/streams/5a0d359f97/commits/aa6a812591) is an example of a chunked obj. That's all there is to it!