### PR TITLE
refactor(transports): inherit from `BaseModel`

### DIFF
--- a/speckle/transports/abstract_transport.py
+++ b/speckle/transports/abstract_transport.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 from pydantic import BaseModel
-from pydantic.dataclasses import dataclass
+from pydantic.main import Extra
 
 #  __________________
 # |                  |
@@ -24,8 +24,7 @@ class Transport(ABC):
         pass
 
 
-@dataclass
-class AbstractTransport(Transport):
+class AbstractTransport(Transport, BaseModel):
     _name: str = "Abstract"
 
     @property
@@ -85,3 +84,7 @@ class AbstractTransport(Transport):
             str -- the string representation of the root object
         """
         pass
+
+    class Config:
+        extra = Extra.allow
+        arbitrary_types_allowed = True

--- a/speckle/transports/memory.py
+++ b/speckle/transports/memory.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 from speckle.logging.exceptions import SpeckleException
 from speckle.transports.abstract_transport import AbstractTransport
 
@@ -8,7 +9,8 @@ class MemoryTransport(AbstractTransport):
     objects: dict = {}
     saved_object_count: int = 0
 
-    def __init__(self, name=None) -> None:
+    def __init__(self, name=None, **data: Any) -> None:
+        super().__init__(**data)
         if name:
             self._name = name
 

--- a/speckle/transports/server.py
+++ b/speckle/transports/server.py
@@ -1,6 +1,6 @@
 import requests
 from asyncio import Queue, Task
-from typing import Dict, List
+from typing import Any, Dict, List, Type
 
 from speckle.api.client import SpeckleClient
 from speckle.logging.exceptions import SpeckleException
@@ -16,7 +16,8 @@ class ServerTransport(AbstractTransport):
     __queue: Queue = None
     __workers: List[Task] = []
 
-    def __init__(self, client: SpeckleClient, stream_id: str) -> None:
+    def __init__(self, client: SpeckleClient, stream_id: str, **data: Any) -> None:
+        super().__init__(**data)
         # TODO: replace client with account or some other auth avenue
         self.url = client.url
         self.stream_id = stream_id

--- a/speckle/transports/sqlite.py
+++ b/speckle/transports/sqlite.py
@@ -3,6 +3,7 @@ import sys
 import time
 import sched
 import sqlite3
+from typing import Any
 from appdirs import user_data_dir
 from contextlib import closing
 from multiprocessing import Process, Queue
@@ -18,13 +19,18 @@ class SQLiteTransport(AbstractTransport):
     _polling_interval = 0.5  # seconds
     __connection: sqlite3.Connection = None
     __queue: Queue = Queue()
-    app_name: str
-    scope: str
+    app_name: str = ""
+    scope: str = ""
     saved_obj_count: int = 0
 
     def __init__(
-        self, base_path: str = None, app_name: str = None, scope: str = None
+        self,
+        base_path: str = None,
+        app_name: str = None,
+        scope: str = None,
+        **data: Any,
     ) -> None:
+        super().__init__(**data)
         self.app_name = app_name or "Speckle"
         self.scope = scope or "Objects"
         base_path = base_path or self.__get_base_path()


### PR DESCRIPTION
default values can no longer be unintentionally mutated and the following should now return the expected results

```py
    mem_a = MemoryTransport()
    mem_b = MemoryTransport()
    mem_a.objects = {"a": 123, "b": 456}

    print(mem_a.objects)  # {"a": 123, "b": 456}
    print(mem_b.objects)  # {}
```

resolves #19