### PR TITLE
☑ Base Attribute Name Validation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,12 @@
       "program": "${file}",
       "console": "integratedTerminal",
       "justMyCode": false
+    },
+    {
+      "name": "Python: Test debug config",
+      "type": "python",
+      "request": "test",
+      "console": "integratedTerminal",
     }
   ]
 }

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,23 @@
+import pytest
+from speckle.objects.base import Base
+
+
+class TestBase:
+    def test_empty_prop_names(self):
+        base = Base()
+        with pytest.raises(ValueError):
+            base[""] = "empty"
+        with pytest.raises(ValueError):
+            base["@"] = "empty"
+
+    def test_invalid_prop_names(self):
+        base = Base()
+
+        with pytest.raises(ValueError):
+            base["@@wow"] = "bad"
+
+        with pytest.raises(ValueError):
+            base["this.is.bad"] = "also bad"
+
+        with pytest.raises(ValueError):
+            base["super/bad"] = "no no no"


### PR DESCRIPTION
enforces rules for `Base` attribute names
- no empty strings (includes `""` and `"@"`)
- no invalid characters: currently list is just `['.', '/']`
- no more than one leading `@`

related to specklesystems/speckle-sharp#37