### PR TITLE
Add infos and fix to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ deleted = client.commit.delete("stream id", "commit id")
 The `BaseObjectSerializer` is used for decomposing and serializing `Base` objects so they can be sent / received to the server. You can use it directly to get the id (hash) and a serializable object representation of the decomposed `Base`. You can learn more about the Speckle `Base` object [here](https://discourse.speckle.works/t/core-2-0-the-base-object/782) and the decomposition API [here](https://discourse.speckle.works/t/core-2-0-decomposition-api/911).
 
 ```py
+from speckle.objects.base import Base
+from speckle.serialization.base_object_serializer import BaseObjectSerializer
+
 detached_base = Base()
 detached_base.name = "this will get detached"
 
@@ -83,6 +86,9 @@ hash, obj_dict = serializer.traverse_base(base_obj)
 If you use the `operations`, you will not need to interact with the serializer directly as this will be taken care of for you. You will just need to provide a transport to indicate where the objects should be sent / received from. At the moment, just the `MemoryTransport` and the `ServerTransport` are fully functional at the moment. If you'd like to learn more about Transports in Speckle 2.0, have a look [here](https://discourse.speckle.works/t/core-2-0-transports/919).
 
 ```py
+from speckle.transports.memory import MemoryTransport
+from speckle.api import operations
+
 transport = MemoryTransport()
 
 # this serialises the object and sends it to the transport
@@ -109,7 +115,7 @@ hash, obj = s.traverse_base(test_base)
 # send it to the server
 objCreate = client.object.create(stream_id="stream id", objects=[obj])
 
-received_base = client.object.get(hash)
+received_base = client.object.get("stream id", hash)
 ```
 
 This doc is not complete - there's more to see so have a dive into the code and play around! Please feel free to provide feedback, submit issues, or discuss new features ✨


### PR DESCRIPTION
* Add some import to make origin of objects / module used explicit
* Fix #L118:
```python
In [46]: received_base = client.object.get(hash)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-46-8171539461b3> in <module>
----> 1 received_base = client.object.get(hash)

TypeError: get() missing 1 required positional argument: 'object_id'
```