### PR TITLE
🧺 Trash the workarounds in ops and serialiser for `speckle_type` vs `speckleType`

### DIFF
--- a/speckle/api/operations.py
+++ b/speckle/api/operations.py
@@ -78,13 +78,7 @@ def receive(
         id=obj_id, target_transport=local_transport
     )
 
-    # if receiving from server, go into the 'data' prop for the actual base obj
-    if isinstance(remote_transport, ServerTransport):
-        return serializer.read_json(
-            obj_string=None, obj_dict=json.loads(obj_string)["data"]
-        )
-    else:
-        return serializer.read_json(obj_string=obj_string)
+    return serializer.read_json(obj_string=obj_string)
 
 
 def serialize(base: Base) -> str:

--- a/speckle/serialization/base_object_serializer.py
+++ b/speckle/serialization/base_object_serializer.py
@@ -206,7 +206,7 @@ class BaseObjectSerializer:
         self.family_tree = {}
         self.closure_table = {}
 
-    def read_json(self, obj_string: str, obj_dict: dict = None) -> Base:
+    def read_json(self, obj_string: str) -> Base:
         """Recomposes a Base object from the string representation of the object
 
         Arguments:
@@ -215,9 +215,9 @@ class BaseObjectSerializer:
         Returns:
             Base -- the base object with all it's children attached
         """
-        if not obj_string and not obj_dict:
+        if not obj_string:
             return None
-        obj = obj_dict or json.loads(obj_string)
+        obj = json.loads(obj_string)
         base = self.recompose_base(obj=obj)
 
         return base

--- a/speckle/serialization/base_object_serializer.py
+++ b/speckle/serialization/base_object_serializer.py
@@ -237,18 +237,11 @@ class BaseObjectSerializer:
         if isinstance(obj, str):
             obj = json.loads(obj)
 
-        # TODO: remove check for `speckleType` when server bug is fixed
         if "speckle_type" in obj and obj["speckle_type"] == "reference":
-            obj = self.get_child(obj=obj)
-        if "speckleType" in obj and obj["speckleType"] == "reference":
             obj = self.get_child(obj=obj)
 
         # initialise the base object using `speckle_type`
-        base = getattr(
-            objects,
-            obj["speckle_type"] if "speckle_type" in obj else obj["speckleType"],
-            Base,
-        )()
+        base = getattr(objects, obj["speckle_type"], Base)()
 
         # get total children count
         if "__closure" in obj:


### PR DESCRIPTION
This removes extra checks that were needed due to a bug in server. Tests will fail as the test server has not been updated to reflect these changes. This will be merged once the test server is up to date.

related to specklesystems/speckle-server#78

fixed in specklesystems/speckle-server@aca61b8