### PR TITLE
🐛 fix(serialiser): smol bug fixes

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -70,3 +70,10 @@ class TestSerialization:
 
         assert isinstance(received, Base)
         assert mesh.get_id(True) == received.get_id()
+
+    def test_unknown_type(self):
+        unknown = '{"speckle_type": "mysterious.type"}'
+        deserialised = operations.deserialize(unknown)
+
+        assert isinstance(deserialised, Base)
+        assert deserialised.speckle_type == "mysterious.type"


### PR DESCRIPTION
- don't overwrite `speckle_type` when receiving unknown object
- check for empty lists on deserialisation
- explicit none check for ignored vals on serialisation
(was unintentionally ignoring `0`s)
- test for unknown type deserialisation


some of this will change w/ #58, 
but needed to merge the fixes for a demo tomorrow