### PR TITLE
🥠 feat(base): support serialisation of all properties

### DIFF
--- a/speckle/api/operations.py
+++ b/speckle/api/operations.py
@@ -66,8 +66,7 @@ def receive(
     # try local transport first. if the parent is there, we assume all the children are there and continue wth deserialisation using the local transport
     obj_string = local_transport.get_object(obj_id)
     if obj_string:
-        base = serializer.read_json(obj_string=obj_string)
-        return base
+        return serializer.read_json(obj_string=obj_string)
 
     if not remote_transport:
         raise SpeckleException(

--- a/speckle/objects/point.py
+++ b/speckle/objects/point.py
@@ -2,7 +2,7 @@ from typing import List
 from speckle.objects.base import Base
 
 
-class Point(Base):
+class Point(Base, speckle_type="Objects.Geometry.Point"):
     value: List[int or float] = [0, 0, 0]
 
     def __repr__(self) -> str:

--- a/speckle/serialization/base_object_serializer.py
+++ b/speckle/serialization/base_object_serializer.py
@@ -54,7 +54,7 @@ class BaseObjectSerializer:
 
         while props:
             prop = props.pop(0)
-            value = obj[prop]
+            value = getattr(obj, prop, None)
 
             # skip nulls or props marked to be ignored with "__" or "_"
             if value is None or prop.startswith(("__", "_")):


### PR DESCRIPTION
- base object `get_member_names` now returns attributes _and_ properties
- all properties are now included in serialisation
- properties without setters will be ignored upon deserialisation 