### PR TITLE
fix(serializer): detached lists

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,6 +83,12 @@ def mesh():
     mesh.test_bases = [Base(name=f"test {i}") for i in range(1, 22)]
     mesh.detach_this = Base(name="predefined detached base")
     mesh["@detach"] = Base(name="detached base")
+    mesh["@detached_list"] = [
+        42,
+        "some text",
+        [1, 2, 3],
+        Base(name="detached within a list"),
+    ]
     mesh.origin = Point(value=[4, 2, 0])
     return mesh
 

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -31,6 +31,7 @@ class TestSerialization:
         assert serialized_dict["detach_this"]["speckle_type"] == "reference"
         assert serialized_dict["@detach"]["speckle_type"] == "reference"
         assert serialized_dict["origin"]["speckle_type"] == "reference"
+        assert serialized_dict["@detached_list"][-1]["speckle_type"] == "reference"
         assert mesh.get_id(True) == deserialized.get_id()
 
     def test_chunking(self, mesh):
@@ -70,15 +71,6 @@ class TestSerialization:
 
         assert isinstance(received, Base)
         assert mesh.get_id(True) == received.get_id()
-
-    def test_serialize(self, base):
-        serialized = operations.serialize(base)
-        deserialized = operations.deserialize(serialized)
-
-        assert base.get_id() == deserialized.get_id()
-        assert base.units == "mm"
-        assert isinstance(base.test_bases[0], Base)
-        assert base["@detach"].name == deserialized["@detach"].name
 
     def test_unknown_type(self):
         unknown = '{"speckle_type": "mysterious.type"}'


### PR DESCRIPTION
oopsie - lists were not being detached properly before. this fixes the issue so dynamically and statically defined detached lists will detach the base objects within the list and leave all other object types as they are. eg, the following attribute:

```py
base["@stuff"] = [Base(), 42, "wow"]
```

will create a list with one reference object, but leave `42 , "wow"` as they are in the list