### PR TITLE
feat(base): improve adding chunkables/detachables

### DIFF
--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -119,7 +119,7 @@ class Base(_RegisteringBase):
         chunkable = {k: v for k, v in kwargs.items() if isinstance(v, int)}
         self._chunkable = dict(self._chunkable, **chunkable)
 
-    def add_detached_attrs(self, names: Set[str]) -> None:
+    def add_detachable_attrs(self, names: Set[str]) -> None:
         """
         Mark defined attributes as detachable for serialisation
 

--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -109,6 +109,25 @@ class Base(_RegisteringBase):
                 "Invalid Name: Base member names cannot contain characters '.' or '/'",
             )
 
+    def add_chunkable_attrs(self, **kwargs: int) -> None:
+        """
+        Mark defined attributes as chunkable for serialisation
+
+        Arguments:
+            kwargs {int} -- the name of the attribute as the keyword and the chunk size as the arg
+        """
+        chunkable = {k: v for k, v in kwargs.items() if isinstance(v, int)}
+        self._chunkable = dict(self._chunkable, **chunkable)
+
+    def add_detached_attrs(self, names: Set[str]) -> None:
+        """
+        Mark defined attributes as detachable for serialisation
+
+        Arguments:
+            names {Set[str]} -- the names of the attributes to detach as a set of strings
+        """
+        self._detachable = self._detachable.union(names)
+
     @property
     def units(self):
         return self._units

--- a/speckle/objects/fakemesh.py
+++ b/speckle/objects/fakemesh.py
@@ -1,5 +1,5 @@
 from speckle.objects.geometry import Point
-from typing import List, Optional
+from typing import List
 
 from .base import Base
 
@@ -26,8 +26,8 @@ class FakeMesh(Base):
 
     def __init__(self, **kwargs) -> None:
         super(FakeMesh, self).__init__(**kwargs)
-        self._chunkable = dict(self._chunkable, **CHUNKABLE_PROPS)
-        self._detachable = self._detachable.union(DETACHABLE)
+        self.add_chunkable_attrs(**CHUNKABLE_PROPS)
+        self.add_detached_attrs(DETACHABLE)
 
     @property
     def origin(self):

--- a/speckle/objects/fakemesh.py
+++ b/speckle/objects/fakemesh.py
@@ -27,7 +27,7 @@ class FakeMesh(Base):
     def __init__(self, **kwargs) -> None:
         super(FakeMesh, self).__init__(**kwargs)
         self.add_chunkable_attrs(**CHUNKABLE_PROPS)
-        self.add_detached_attrs(DETACHABLE)
+        self.add_detachable_attrs(DETACHABLE)
 
     @property
     def origin(self):

--- a/speckle/objects/geometry.py
+++ b/speckle/objects/geometry.py
@@ -102,7 +102,7 @@ class Polyline(Base, speckle_type=GEOMETRY + "Polyline"):
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)
-        self._chunkable = dict(self._chunkable, value=20000)
+        self.add_chunkable_attrs(value=20000)
 
     @classmethod
     def from_points(cls, points: List[Point]):
@@ -150,9 +150,7 @@ class Curve(Base, speckle_type=GEOMETRY + "Curve"):
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)
-        self._chunkable = dict(
-            self._chunkable, points=20000, weights=20000, knots=20000
-        )
+        self.add_chunkable_attrs(points=20000, weights=20000, knots=20000)
 
     def as_points(self) -> List[Point]:
         """Converts the `value` attribute to a list of Points"""
@@ -200,12 +198,8 @@ class Mesh(Base, speckle_type=GEOMETRY + "Mesh"):
 
     def __init__(self, **data) -> None:
         super().__init__(**data)
-        self._chunkable = dict(
-            self._chunkable,
-            vertices=2000,
-            faces=2000,
-            colors=2000,
-            textureCoordinates=2000,
+        self.add_chunkable_attrs(
+            vertices=2000, faces=2000, colors=2000, textureCoordinates=2000
         )
 
 
@@ -330,19 +324,16 @@ class Brep(Base, speckle_type=GEOMETRY + "Brep"):
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)
-        self._detachable.update({"displayValue"})
-        self._chunkable = dict(
-            self._chunkable,
-            **{
-                "Surfaces": 200,
-                "Curve3D": 200,
-                "Curve2D": 200,
-                "Vertices": 5000,
-                "Edges": 5000,
-                "Loops": 5000,
-                "Trims": 5000,
-                "Faces": 5000,
-            },
+        self.add_detached_attrs({"displayValue"})
+        self.add_chunkable_attrs(
+            Surfaces=200,
+            Curve3D=200,
+            Curve2D=200,
+            Vertices=5000,
+            Edges=5000,
+            Loops=5000,
+            Trims=5000,
+            Faces=5000,
         )
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/speckle/objects/geometry.py
+++ b/speckle/objects/geometry.py
@@ -324,7 +324,7 @@ class Brep(Base, speckle_type=GEOMETRY + "Brep"):
 
     def __init__(self, **data: Any) -> None:
         super().__init__(**data)
-        self.add_detached_attrs({"displayValue"})
+        self.add_detachable_attrs({"displayValue"})
         self.add_chunkable_attrs(
             Surfaces=200,
             Curve3D=200,


### PR DESCRIPTION
adds helper methods on `Base` that can be called in the constructors
to prevent ppl messing this up when defining their own objects