### PR TITLE
fix(base): specify full name for datachunk

### DIFF
--- a/speckle/objects/base.py
+++ b/speckle/objects/base.py
@@ -253,5 +253,5 @@ class Base(_RegisteringBase):
         extra = Extra.allow
 
 
-class DataChunk(Base):
+class DataChunk(Base, speckle_type="Speckle.Core.Models.DataChunk"):
     data: List[Any] = []


### PR DESCRIPTION
would bork in other connectors with name as just `DataChunk`