### PR TITLE
ci: Spin-up new server for each test run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,30 @@ version: 2.1
 
 orbs:
   python: circleci/python@1.3.2
-  
+
 jobs:
   build:
-    executor: 
-      name: python/default
-      tag: << parameters.tag >>
+    docker:
+      - image: "cimg/python:<<parameters.tag>>"
+      - image: "circleci/node:12"
+      - image: "circleci/redis:6"
+      - image: "circleci/postgres:12"
+        environment:
+          POSTGRES_DB: speckle2_test
+          POSTGRES_PASSWORD: speckle
+          POSTGRES_USER: speckle
+      - image: "speckle/speckle-server:5f8cf11cba07ea6a54000243f9cb343b61cbba13"
+        command: ["bash", "-c", "/wait && node bin/www"]
+        environment:
+          POSTGRES_URL: "localhost"
+          POSTGRES_USER: "speckle"
+          POSTGRES_PASSWORD: "speckle"
+          POSTGRES_DB: "speckle2_test"
+          REDIS_URL: "redis://localhost"
+          SESSION_SECRET: "keyboard cat"
+          STRATEGY_LOCAL: "true"
+          CANONICAL_URL: "http://localhost:3000"
+          WAIT_HOSTS: localhost:5432, localhost:6379
     parameters:
       tag:
         default: "3.8"
@@ -15,13 +33,13 @@ jobs:
     steps:
       - checkout
       - run: python --version
-      - run: 
+      - run:
           command: python -m pip install --upgrade pip
           name: upgrade pip
       - python/install-packages:
           pip-dependency-file: requirements.txt
           pkg-manager: pip
-      - run:  pytest --version
+      - run: pytest --version
 
 workflows:
   main:
@@ -32,4 +50,3 @@ workflows:
               version: ["3.6", "3.7", "3.8", "3.9"]
           pkg-manager: pip
           test-tool: pytest
-          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - python/install-packages:
           pip-dependency-file: requirements.txt
           pkg-manager: pip
-      - run: pytest --version
+      - run: pytest
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,7 @@ jobs:
 workflows:
   main:
     jobs:
-      - build
-      # - python/test:
-      #     matrix:
-      #       parameters:
-      #         version: ["3.6", "3.7", "3.8", "3.9"]
-      #     pkg-manager: pip
-      #     test-tool: pytest
+      - build:
+          matrix:
+            parameters:
+              tag: ["3.6", "3.7", "3.8", "3.9"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,10 @@ jobs:
 workflows:
   main:
     jobs:
-      - python/test:
-          matrix:
-            parameters:
-              version: ["3.6", "3.7", "3.8", "3.9"]
-          pkg-manager: pip
-          test-tool: pytest
+      - build
+      # - python/test:
+      #     matrix:
+      #       parameters:
+      #         version: ["3.6", "3.7", "3.8", "3.9"]
+      #     pkg-manager: pip
+      #     test-tool: pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from specklepy.objects.fakemesh import FakeMesh
 
 @pytest.fixture(scope="session")
 def host():
-    return "latest.speckle.dev"
+    return "localhost:3000"
 
 
 def seed_user(host):
@@ -24,13 +24,14 @@ def seed_user(host):
     }
 
     r = requests.post(
-        url=f"https://{host}/auth/local/register?challenge=pyspeckletests",
+        url=f"http://{host}/auth/local/register?challenge=pyspeckletests",
         data=user_dict,
     )
+    print(r.url)
     access_code = r.url.split("access_code=")[1]
 
     r_tokens = requests.post(
-        url=f"https://{host}/auth/token",
+        url=f"http://{host}/auth/token",
         json={
             "appSecret": "spklwebapp",
             "appId": "spklwebapp",
@@ -56,7 +57,7 @@ def second_user_dict(host):
 
 @pytest.fixture(scope="session")
 def client(host, user_dict):
-    client = SpeckleClient(host=host, use_ssl=True)
+    client = SpeckleClient(host=host, use_ssl=False)
     client.authenticate(user_dict["token"])
     return client
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,13 +24,13 @@ def seed_user(host):
     }
 
     r = requests.post(
-        url=f"https://{host}/auth/local/register?challenge=pyspeckletests",
+        url=f"http://{host}/auth/local/register?challenge=pyspeckletests",
         data=user_dict,
     )
     access_code = r.url.split("access_code=")[1]
 
     r_tokens = requests.post(
-        url=f"https://{host}/auth/token",
+        url=f"http://{host}/auth/token",
         json={
             "appSecret": "spklwebapp",
             "appId": "spklwebapp",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from specklepy.objects.fakemesh import FakeMesh
 
 @pytest.fixture(scope="session")
 def host():
-    return "latest.speckle.dev"
+    return "localhost:3000"
 
 
 def seed_user(host):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from specklepy.objects.fakemesh import FakeMesh
 
 @pytest.fixture(scope="session")
 def host():
-    return "localhost:3000"
+    return "latest.speckle.dev"
 
 
 def seed_user(host):
@@ -24,13 +24,13 @@ def seed_user(host):
     }
 
     r = requests.post(
-        url=f"http://{host}/auth/local/register?challenge=pyspeckletests",
+        url=f"https://{host}/auth/local/register?challenge=pyspeckletests",
         data=user_dict,
     )
     access_code = r.url.split("access_code=")[1]
 
     r_tokens = requests.post(
-        url=f"http://{host}/auth/token",
+        url=f"https://{host}/auth/token",
         json={
             "appSecret": "spklwebapp",
             "appId": "spklwebapp",


### PR DESCRIPTION
As discussed, all tests are now wired up to run against `localhost:3000`.
CI config now spins up a new speckle server in the same way we're doing so for .Net

 Python tests should be run against your own local server if needed.