### PR TITLE
Fix failing tests

### DIFF
--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -1,5 +1,7 @@
-from specklepy.api.models import Branch, Commit, Stream
 import pytest
+from specklepy.api import operations
+from specklepy.transports.server import ServerTransport
+from specklepy.api.models import Branch, Commit, Stream
 
 
 class TestBranch:
@@ -31,6 +33,9 @@ class TestBranch:
         assert isinstance(branch.id, str)
 
     def test_branch_get(self, client, mesh, stream, branch):
+        transport = ServerTransport(client=client, stream_id=stream.id)
+        mesh.id = operations.send(mesh, transports=[transport])
+
         client.commit.create(
             stream_id=stream.id,
             branch_name=branch.name,

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,5 +1,7 @@
 import pytest
+from specklepy.api import operations
 from specklepy.api.models import Commit, Stream
+from specklepy.transports.server.server import ServerTransport
 
 
 @pytest.mark.run(order=4)
@@ -27,6 +29,9 @@ class TestCommit:
         return stream
 
     def test_commit_create(self, client, stream, mesh, commit):
+        transport = ServerTransport(client=client, stream_id=stream.id)
+        mesh.id = operations.send(mesh, transports=[transport])
+
         commit.id = client.commit.create(
             stream_id=stream.id, object_id=mesh.id, message=commit.message
         )


### PR DESCRIPTION
after many `console.log`s, I realised the real issue was that I was sharing objects across streams. due to cristi's new security patches, this is no longer possible! oopsies, all fixed now 😊

closes #83 