### PR TITLE
fix(serializer): handle receiving `None` vals

### DIFF
--- a/specklepy/serialization/base_object_serializer.py
+++ b/specklepy/serialization/base_object_serializer.py
@@ -277,8 +277,8 @@ class BaseObjectSerializer:
             base.totalChildrenCount = len(closure)
 
         for prop, value in obj.items():
-            # 1. handle primitives (ints, floats, strings, and bools)
-            if isinstance(value, PRIMITIVES):
+            # 1. handle primitives (ints, floats, strings, and bools) or None
+            if isinstance(value, PRIMITIVES) or value is None:
                 base.__setattr__(prop, value)
                 continue
 


### PR DESCRIPTION
couldn't replicate #88 but i found this error w the stuff i was trying to receive when i dug a bit deeper, so maybe it was related? happened w a rhino 7 commit - wasn't handled before bc from what I understood we were not serialising nulls.
