### PR TITLE
Fix: path process error on Linux #96

### DIFF
--- a/specklepy/api/resources/__init__.py
+++ b/specklepy/api/resources/__init__.py
@@ -5,7 +5,7 @@ import pkgutil
 from importlib import import_module
 
 
-for (_, name, _) in pkgutil.iter_modules([Path(__file__).parent]):
+for (_, name, _) in pkgutil.iter_modules(__path__):
 
     imported_module = import_module("." + name, package=__name__)
 


### PR DESCRIPTION
This fix the issue #96 on my system but you might want to test on Windows too.

This modification was inspired by: https://stackoverflow.com/questions/3365740/how-to-import-all-submodules