### PR TITLE
add metadata and py.typed to include type definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ license = "Apache-2.0"
 repository = "https://github.com/specklesystems/speckle-py"
 documentation = "https://speckle.guide/dev/py-examples.html"
 homepage = "https://speckle.systems/"
+classifiers = [
+    "Typing :: Typed",
+    "Programming Language :: Python :: 3",
+]
 
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
With the `py.typed` file the types should be included when distributing
the package.

Read more here: https://www.python.org/dev/peps/pep-0561/